### PR TITLE
Refactor constants & rename action arguments

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Lint
         run: yarn lint
       - name: Test
-        run: yarn jest
+        run: yarn test
       - name: Build
         run: yarn build

--- a/action.yml
+++ b/action.yml
@@ -8,11 +8,6 @@ inputs:
   summary:
     required: true
     description: |
-      A brief text summary of the event, used to generate the summaries/titles of any associated alerts. 
-      The maximum permitted length of this property is 1024 characters.
-  description:
-    required: true
-    description: |
       A longer text description of the event, which can include instructions to further investigate
       or resolve the incident.
   severity:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,0 @@
-export const PD_INTEGRATION_KEY = "pd-integration-key";
-export const SUMMARY = "summary";
-export const SEVERITY = "severity";
-export const DESCRIPTION = "description";

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,0 +1,9 @@
+import * as core from "@actions/core";
+
+function resolveInput(key: string): string {
+  return core.getInput(key);
+}
+
+export const PD_INTEGRATION_KEY = resolveInput("pd-integration-key");
+export const SEVERITY = resolveInput("severity");
+export const SUMMARY = resolveInput("summary");


### PR DESCRIPTION
## Summary
Clean up constants that refer to inputs/resolve them directly when importing the constants & clean up some other arguments.

## Possible downsides?
N/A
