### PR TITLE
Update dedup_key to consolidate alerts at the (action,ref) level

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ async function run(): Promise<void> {
             service: inputs.SERVICE,
           },
         },
-        dedup_key: `${context.action}-${github.context.runId}`,
+        dedup_key: `${github.context.action}-${github.context.ref}`,
         links: [
           {
             href: runUrl,


### PR DESCRIPTION
## Before this PR
We encountered cases where a job would continually fail & generate a large number of alerts. In these situations, a single alert that consolidates all failures is desirable since it reduces noise.

## After this PR
Update the `dedup_key` to properly consolidate failures for each unique (action, ref) pair.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

