### PR TITLE
Properly key on workflow name rather than action

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ async function run(): Promise<void> {
             service: inputs.SERVICE,
           },
         },
-        dedup_key: `${github.context.action}-${github.context.ref}`,
+        dedup_key: `${context.repo}-${context.workflow}-${context.ref}`,
         links: [
           {
             href: runUrl,


### PR DESCRIPTION
## Before this PR
We noticed that certain alerts weren't firing since we were incorrectly keying on `github.context.action` (ie. `__theoremlp_pagerduty-alert-refs/heads/main`) rather than `<workflow_name>-refs/heads/main`

## After this PR
Update the deup key to correctly use the workflow name, as opposed to the action name

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

