### PR TITLE
Always ensure unique dedup key

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ async function run(): Promise<void> {
             service: inputs.SERVICE,
           },
         },
-        dedup_key: `${context.repo}-${context.workflow}-${context.ref}`,
+        dedup_key: `${context.repo}-${context.workflow}-${context.runId}`,
         links: [
           {
             href: runUrl,


### PR DESCRIPTION
## Before this PR
It was possible for us to fail to alert on repeated workflow failures since we always deduped by `ref`

## After this PR
Always ensure dedup key is unique by keying on the GHA `runId`

## Possible downsides?
Certain alerts like CD broken on a deployment branch will now fire multiple times, but this is preferable compared to an unresolved (stale) alert blocking new ones from firing

