### PR TITLE
Bump Deprecated Node Version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ inputs:
     required: true
     description: The PagerDuty Service to route the alert to.
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
## Before this PR
I'm getting a bunch of warnings that node16 is deprecated.

## After this PR
We should be up to date.

## Possible downsides?
Not sure how to test this.
